### PR TITLE
Add ternary cube demo and documentation

### DIFF
--- a/Clisa/CLisa_Prime/casino1031.cpp
+++ b/Clisa/CLisa_Prime/casino1031.cpp
@@ -1,14 +1,23 @@
 #include <boost/multiprecision/cpp_int.hpp>
 #include <random>
 #include <iostream>
+#include <array>
 
 // Utility using directive for the big integer type.
 using boost::multiprecision::cpp_int;
 
-// Forward declarations
+// Forward declarations for the main helpers.
 bool millerRabin(const cpp_int &n, int iterations = 25);
 cpp_int modPow(cpp_int base, cpp_int exp, const cpp_int &mod);
 cpp_int random2084Bit();
+
+// Helper structures for the ternary 3x3x3 cube example.
+struct TernaryCube {
+    bool* cells[3][3][3];  // nullptr means 0, otherwise true => 1, false => -1
+};
+
+TernaryCube generateTernaryCube(std::mt19937_64 &gen);
+void freeTernaryCube(TernaryCube &cube);
 
 // -----------------------------------------------------------------------------
 // Entry point demonstrating the usage of the helpers above.
@@ -16,6 +25,25 @@ cpp_int random2084Bit();
 int main() {
     cpp_int candidate = random2084Bit();
     std::cout << "Random 2084-bit candidate:" << std::endl << candidate << std::endl;
+
+    // Generate a demo ternary cube using the same RNG.
+    std::mt19937_64 gen(std::random_device{}());
+    TernaryCube cube = generateTernaryCube(gen);
+
+    std::cout << "\nTernary cube values:" << std::endl;
+    for (int x = 0; x < 3; ++x) {
+        for (int y = 0; y < 3; ++y) {
+            for (int z = 0; z < 3; ++z) {
+                bool *ptr = cube.cells[x][y][z];
+                int val = ptr ? (*ptr ? 1 : -1) : 0;
+                std::cout << val << ' ';
+            }
+            std::cout << " | ";
+        }
+        std::cout << std::endl;
+    }
+
+    freeTernaryCube(cube);
 
     if (millerRabin(candidate)) {
         std::cout << "Candidate is probably prime." << std::endl;
@@ -30,12 +58,15 @@ int main() {
 // This mimics Python's os.urandom by using std::random_device as entropy source.
 // -----------------------------------------------------------------------------
 cpp_int random2084Bit() {
-    std::random_device rd;              // Non-deterministic seed.
+    // Use hardware entropy if available. Keeping the seed secret makes the
+    // pseudo-random sequence unpredictable, which is desirable for crypto.
+    std::random_device rd;              // Non-deterministic seed source.
     std::mt19937_64 gen(rd());          // 64-bit Mersenne Twister engine.
     cpp_int result = 0;
     int bits = 2084;
 
-    // Build the number 64 bits at a time.
+    // Build the number in 64-bit blocks. Each chunk can be reused as a
+    // building block for other structures (e.g. 3x3x3 cubes).
     for (int produced = 0; produced < bits; produced += 64) {
         result <<= 64;                  // Make room for the next chunk.
         result |= static_cast<uint64_t>(gen());
@@ -104,4 +135,32 @@ bool millerRabin(const cpp_int &n, int iterations) {
             return false;               // Composite number.
     }
     return true;                        // Probably prime.
+}
+
+// -----------------------------------------------------------------------------
+// Create a 3x3x3 cube where each cell is a pointer to bool.
+// nullptr -> 0, true -> 1, false -> -1.
+// -----------------------------------------------------------------------------
+TernaryCube generateTernaryCube(std::mt19937_64 &gen) {
+    std::uniform_int_distribution<int> dist(0, 2); // 0:nil, 1:true, 2:false
+    TernaryCube cube{};
+    for (int x = 0; x < 3; ++x)
+        for (int y = 0; y < 3; ++y)
+            for (int z = 0; z < 3; ++z) {
+                int sel = dist(gen);
+                if (sel == 0) {
+                    cube.cells[x][y][z] = nullptr;
+                } else {
+                    cube.cells[x][y][z] = new bool(sel == 1);
+                }
+            }
+    return cube;
+}
+
+// Release the dynamically allocated booleans within the cube.
+void freeTernaryCube(TernaryCube &cube) {
+    for (int x = 0; x < 3; ++x)
+        for (int y = 0; y < 3; ++y)
+            for (int z = 0; z < 3; ++z)
+                delete cube.cells[x][y][z];
 }

--- a/Clisa/CLisa_Prime/casino1031_readme.md
+++ b/Clisa/CLisa_Prime/casino1031_readme.md
@@ -1,0 +1,21 @@
+# casino1031 README
+
+Below is a small roadmap of seven tasks used to structure the C++ prototype.
+Each point comes with a short explanation and the associated action.
+
+1. **Random seed reliability** – ensure that `std::random_device` provides
+   unpredictable entropy. The generated seed must remain secret to keep the
+   pseudo-random sequence secure.
+2. **Big integer handling** – use Boost.Multiprecision (`cpp_int`) to manage
+   integers bigger than 64 bits.
+3. **Analyse the existing code** – understand `random2084Bit()`, `modPow()` and
+   `millerRabin()`.
+4. **Simplify the interface** – expose a small API for generating a random
+   2084‑bit candidate and checking its primality.
+5. **Unit tests** – validate the size of the random number and the behaviour of
+   the primality test.
+6. **Documentation** – comment the code block by block (see `casino1031.cpp`).
+7. **Integration** – plan for multithreaded CPU execution in future modules.
+
+This file accompanies `casino1031.cpp`, which now includes a demo function
+`generateTernaryCube` producing a 3×3×3 cube of ternary values (−1, 0, 1).


### PR DESCRIPTION
## Summary
- document dev tasks in a new `casino1031_readme.md`
- add comments clarifying randomness and 64‑bit blocks
- add `generateTernaryCube` and `freeTernaryCube` helpers
- show cube generation inside `main`

## Testing
- `g++ -std=c++17 Clisa/CLisa_Prime/casino1031.cpp -o Clisa/CLisa_Prime/casino1031` *(fails: boost headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_6871d11e433883299869ee8118ceca5d