### PR TITLE
Add ternary tensor example

### DIFF
--- a/ternary_tensor.cpp
+++ b/ternary_tensor.cpp
@@ -1,0 +1,85 @@
+#include <array>
+#include <random>
+#include <iostream>
+#include <boost/multiprecision/cpp_int.hpp>
+
+using boost::multiprecision::cpp_int;
+
+// -----------------------------------------------------------------------------
+// Simple structure representing a 3x3x3 tensor with ternary values {-1, 0, 1}.
+// The tensor is stored as a flat std::array for simplicity.
+// -----------------------------------------------------------------------------
+struct TernaryTensor {
+    std::array<int, 27> data{};  // 3*3*3 = 27 elements
+
+    // Access element at position (x, y, z).
+    int& operator()(int x, int y, int z) {
+        return data[x * 9 + y * 3 + z];
+    }
+
+    // Const access for read-only operations.
+    int operator()(int x, int y, int z) const {
+        return data[x * 9 + y * 3 + z];
+    }
+};
+
+// -----------------------------------------------------------------------------
+// Generate a tensor filled with random {-1, 0, 1} values.
+// Uses std::random_device and std::mt19937 for repeatable randomness.
+// -----------------------------------------------------------------------------
+TernaryTensor randomTensor() {
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<int> dist(-1, 1);
+
+    TernaryTensor t;
+    for (int i = 0; i < 27; ++i) {
+        t.data[i] = dist(gen);
+    }
+    return t;
+}
+
+// -----------------------------------------------------------------------------
+// Convert the tensor into a big integer using base-3 encoding.
+// This demonstrates how Boost.Multiprecision handles integers larger than 64 bits.
+// -----------------------------------------------------------------------------
+cpp_int tensorToBigInt(const TernaryTensor& t) {
+    cpp_int result = 0;
+    for (int i = 0; i < 27; ++i) {
+        result *= 3;                     // Shift to next ternary digit
+        result += t.data[i] + 1;         // Map {-1,0,1} -> {0,1,2}
+    }
+    return result;
+}
+
+// -----------------------------------------------------------------------------
+// Pretty-print the tensor layer by layer.
+// -----------------------------------------------------------------------------
+void printTensor(const TernaryTensor& t) {
+    for (int x = 0; x < 3; ++x) {
+        std::cout << "Layer " << x << ":\n";
+        for (int y = 0; y < 3; ++y) {
+            for (int z = 0; z < 3; ++z) {
+                std::cout << t(x, y, z) << ' ';
+            }
+            std::cout << '\n';
+        }
+        std::cout << '\n';
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Entry point: generate a random tensor, display it and its integer encoding.
+// -----------------------------------------------------------------------------
+int main() {
+    TernaryTensor t = randomTensor();
+    std::cout << "Random 3x3x3 ternary tensor:" << std::endl;
+    printTensor(t);
+
+    cpp_int value = tensorToBigInt(t);
+    std::cout << "Base-3 encoded as big integer:" << std::endl;
+    std::cout << value << std::endl;
+
+    return 0;
+}
+

--- a/ternary_tensor_README.md
+++ b/ternary_tensor_README.md
@@ -1,0 +1,46 @@
+# Ternary Tensor Example
+
+This mini-program demonstrates how to represent a 3&times;3&times;3 tensor of ternary values and encode it as a large integer. It also serves as a playground for Boost.Multiprecision.
+
+## 7 stray thoughts (and matching tasks)
+
+1. **Pick a multiprecision library wisely.**  
+   *Task:* Here we use `boost::multiprecision::cpp_int` because it's header-only and easy to drop in.
+2. **Keep tensors small but conceptually expandable.**  
+   *Task:* Implement `TernaryTensor` as an array, so swapping in a bigger shape later is trivial.
+3. **Randomness matters.**  
+   *Task:* Seed an `std::mt19937` with `std::random_device` for repeatable runs that still look random.
+4. **Conversion logic reveals structure.**  
+   *Task:* Provide `tensorToBigInt` to show how base‑3 digits map to a giant integer.
+5. **Readable output beats raw data.**  
+   *Task:* `printTensor` formats the tensor layer by layer—no more peering at hex dumps.
+6. **Short example, long reach.**  
+   *Task:* Put everything in one file so it compiles anywhere without a build system.
+7. **Leave room for sarcasm.**  
+   *Task:* End with a note reminding the reader that bigger projects await.
+
+## Code walkthrough
+
+- **`struct TernaryTensor`** – stores 27 integers and provides `(x,y,z)` indexing.
+- **`randomTensor()`** – fills a tensor with random values in {-1,0,1}.
+- **`tensorToBigInt()`** – encodes the tensor in base&nbsp;3 using Boost.Multiprecision.
+- **`printTensor()`** – prints each 3&times;3 layer for clarity.
+- **`main()`** – glues everything together and dumps the final integer.
+
+## Libraries
+
+- `<array>` and `<random>` from the STL
+- `<boost/multiprecision/cpp_int.hpp>` for arbitrary-size integers
+
+## Building
+
+```bash
+g++ -std=c++17 ternary_tensor.cpp -o ternary_tensor
+./ternary_tensor
+```
+
+No special linker flags are required because `cpp_int` is header-only.
+
+## Final note
+
+Good luck scaling this up to something useful—you might need it.


### PR DESCRIPTION
## Summary
- explore multiprecision with Boost
- show how to encode a 3x3x3 tensor of {-1,0,1}
- add README with humorous explanations

## Testing
- `g++ -std=c++17 ternary_tensor.cpp -o ternary_tensor`
- `./ternary_tensor | head`

------
https://chatgpt.com/codex/tasks/task_e_6871d68f40c4832992e13a7b13db91e5