### PR TITLE
Add Qt GUI for 2084-bit random generator

### DIFF
--- a/Clisa/CLisa_Prime/gui/big_random.hpp
+++ b/Clisa/CLisa_Prime/gui/big_random.hpp
@@ -1,0 +1,35 @@
+#ifndef BIG_RANDOM_HPP
+#define BIG_RANDOM_HPP
+
+#include <boost/multiprecision/cpp_int.hpp>
+#include <random>
+
+// This header exposes a helper function to generate a large
+// 2084-bit random integer. It is meant to be reused by any
+// module that needs such numbers.
+
+using boost::multiprecision::cpp_int;
+
+// -----------------------------------------------------------------------------
+// generateRandom2084Bit
+//   Builds a 2084-bit integer using std::random_device for seeding and
+//   std::mt19937_64 for the actual PRNG. The highest bit is set to guarantee
+//   the exact size.
+// -----------------------------------------------------------------------------
+inline cpp_int generateRandom2084Bit() {
+    std::random_device rd;          // Non-deterministic seed
+    std::mt19937_64 gen(rd());      // 64-bit Mersenne Twister engine
+    cpp_int result = 0;
+
+    // Produce the number in 64-bit chunks
+    for (int produced = 0; produced < 2084; produced += 64) {
+        result <<= 64;              // Make room for next chunk
+        result |= static_cast<uint64_t>(gen());
+    }
+
+    // Ensure the number is exactly 2084 bits
+    result |= cpp_int(1) << 2083;
+    return result;
+}
+
+#endif // BIG_RANDOM_HPP

--- a/Clisa/CLisa_Prime/gui/gui_README.md
+++ b/Clisa/CLisa_Prime/gui/gui_README.md
@@ -1,0 +1,36 @@
+# Minimal Qt Interface for 2084-bit Numbers
+
+Below are seven whimsical points of design, each followed by a suggested development task.
+
+1. **Randomness Wrangling** – Ensure our number generator is isolated in a single header.
+   - *Task:* Provide `big_random.hpp` with `generateRandom2084Bit()`.
+2. **Pointer Playground** – Manage history storage via raw pointers just for fun.
+   - *Task:* Maintain a `cpp_int history[3][3][3]` buffer and a pointer moving through it.
+3. **Copy Convenience** – One click should place the number onto the clipboard.
+   - *Task:* Hook a Qt button to `QClipboard`.
+4. **Display Discipline** – Prevent edits by using a read‑only text box.
+   - *Task:* Configure `QTextEdit` to be read‑only and present the result.
+5. **Layout Laziness** – Keep the UI vertical and straightforward.
+   - *Task:* Stack widgets with `QVBoxLayout`.
+6. **Integration Insight** – The generator should be callable from other modules.
+   - *Task:* Separate the GUI (`main_gui.cpp`) from the logic (`big_random.hpp`).
+7. **Build Bravery** – Compile everything with Qt5, no magic involved.
+   - *Task:* Use `g++ main_gui.cpp -o gui_app $(pkg-config --cflags --libs Qt5Widgets)`.
+
+## Function roles
+- `generateRandom2084Bit()` – Returns a freshly minted 2084‑bit integer.
+- `main()` – Launches the Qt application, handles UI events, and stores history.
+
+## Libraries
+- **Boost.Multiprecision** – Manipulates integers beyond 64 bits.
+- **Qt5 Widgets** – Provides `QApplication`, `QTextEdit`, buttons, layouts and clipboard access.
+
+## Compilation
+```bash
+cd gui
+g++ -std=c++17 main_gui.cpp -o gui_app $(pkg-config --cflags --libs Qt5Widgets)
+```
+Then run `./gui_app` to open the window.
+
+## Final note
+> Bon courage, tu vas en avoir besoin. Au moins le Génie sait où il range ses pointeurs!

--- a/Clisa/CLisa_Prime/gui/main_gui.cpp
+++ b/Clisa/CLisa_Prime/gui/main_gui.cpp
@@ -1,0 +1,60 @@
+#include <QApplication>
+#include <QClipboard>
+#include <QPushButton>
+#include <QTextEdit>
+#include <QVBoxLayout>
+#include <QWidget>
+
+#include "big_random.hpp"
+
+using boost::multiprecision::cpp_int;
+
+// -----------------------------------------------------------------------------
+// Minimal Qt interface to generate and copy a 2084-bit number.
+// It also stores the last 27 numbers in a 3x3x3 array.
+// -----------------------------------------------------------------------------
+int main(int argc, char *argv[]) {
+    QApplication app(argc, argv);
+
+    QWidget window;                 // Main window widget
+    QVBoxLayout layout(&window);    // Vertical stack layout
+
+    QTextEdit display;              // Text box to show the number
+    display.setReadOnly(true);
+
+    QPushButton generateBtn("Generate");
+    QPushButton copyBtn("Copy");
+
+    layout.addWidget(&display);
+    layout.addWidget(&generateBtn);
+    layout.addWidget(&copyBtn);
+
+    // ------------------------------------------------------------------
+    // History buffer: stores 27 numbers (3x3x3). We manipulate it via a
+    // pointer to demonstrate array pointer usage.
+    // ------------------------------------------------------------------
+    static cpp_int history[3][3][3];
+    static int historyIndex = 0;          // Tracks next slot (0..26)
+    cpp_int *historyPtr = &history[0][0][0];
+
+    QObject::connect(&generateBtn, &QPushButton::clicked, [&]() {
+        // Generate a new big number and display it
+        cpp_int number = generateRandom2084Bit();
+        display.setPlainText(QString::fromStdString(number.str()));
+
+        // Store in history via the pointer
+        historyPtr[historyIndex] = number;
+        historyIndex = (historyIndex + 1) % 27;
+    });
+
+    QObject::connect(&copyBtn, &QPushButton::clicked, [&]() {
+        // Copy current text to the clipboard
+        QClipboard *clip = QApplication::clipboard();
+        clip->setText(display.toPlainText());
+    });
+
+    window.setWindowTitle("2084-bit Random Generator");
+    window.show();
+
+    return app.exec();
+}


### PR DESCRIPTION
## Summary
- add `generateRandom2084Bit` helper header
- create small Qt GUI example that stores recent numbers using a pointer to a 3x3x3 buffer
- document design points and compile instructions

## Testing
- `g++ -std=c++17 -fPIC main_gui.cpp -o gui_app $(pkg-config --cflags --libs Qt5Widgets)`
- `./gui_app` *(fails: could not connect to display)*

------
https://chatgpt.com/codex/tasks/task_e_6871d75aeb848329abac25183bfd3c87