### PR TITLE
Improve ROCm and Triton setup scripts

### DIFF
--- a/Clisa/triton_build.sh
+++ b/Clisa/triton_build.sh
@@ -10,8 +10,8 @@ git clone https://github.com/triton-lang/triton.git
 cd triton
 
 python3 -m venv .venv --prompt triton
-python3 -m pip install --upgrade pip setuptools wheel
 source .venv/bin/activate
+pip install --upgrade pip setuptools wheel
 pip install -r python/requirements.txt 		# build-time dependencies
 pip install -e . --no-build-isolation
 

--- a/codex_summaries/setup_check_20250714_204527.md
+++ b/codex_summaries/setup_check_20250714_204527.md
@@ -1,0 +1,11 @@
+# ROCm and Triton setup check
+
+## rocm_cfg_check.sh
+- Added check for existing ROCm installation.
+- Defines desired version `6.4.1` and compares with installed one.
+- Skips installation if version matches.
+
+## triton_build.sh
+- Activates Python virtual environment before upgrading `pip`.
+- General cleanup for reliable environment setup.
+

--- a/rocm_cfg_check.sh
+++ b/rocm_cfg_check.sh
@@ -1,6 +1,23 @@
 #!/bin/bash
 set -e
 
+# Desired ROCm version
+ROCM_VERSION="6.4.1"
+
+# Check if ROCm is already installed and matches desired version
+if ls /opt | grep -q "rocm-"; then
+    INSTALLED_VERSION=$(ls -d /opt/rocm-* 2>/dev/null | head -n1 | sed 's|/opt/rocm-||')
+    if [ "$INSTALLED_VERSION" = "$ROCM_VERSION" ]; then
+        echo "ROCm $ROCM_VERSION already installed. Nothing to do."
+        exit 0
+    else
+        echo "ROCm $INSTALLED_VERSION detected, but version $ROCM_VERSION requested."
+        echo "Continuing with installation of ROCm $ROCM_VERSION..."
+    fi
+else
+    echo "No existing ROCm installation detected. Installing ROCm $ROCM_VERSION..."
+fi
+
 # Make the directory if it doesn't exist yet.
 # This location is recommended by the distribution maintainers.
 sudo mkdir --parents --mode=0755 /etc/apt/keyrings


### PR DESCRIPTION
## Summary
- add version detection logic to `rocm_cfg_check.sh`
- fix virtualenv setup order in `triton_build.sh`
- record analysis in `codex_summaries/setup_check_20250714_204527.md`

## Testing
- `shellcheck rocm_cfg_check.sh Clisa/triton_build.sh`
- `sudo apt-get update && sudo apt-get install -y shellcheck`


------
https://chatgpt.com/codex/tasks/task_e_68756bbc61dc83299b64a2e0c9d169ea