### PR TITLE
Add Clisa summaries

### DIFF
--- a/Clisa/AGENTS.md
+++ b/Clisa/AGENTS.md
@@ -17,3 +17,13 @@ if __name__ == "__main__":
 7. AGENT inserted automatically
 
 La logique ricane, un brin mélancolique.
+
+---
+### Aperçu technique en 7 points
+1. Le script `triton_build.sh` automatise le clonage et la compilation de Triton dans un environnement virtuel Python.
+2. `README.md` décrit la migration de modules Python/Zeph vers du C puis vers Triton pour exploiter les GPU MI300X.
+3. Le dossier `CLisa_Prime/` regroupe des prototypes en C/C++ manipulant nombres aléatoires et structures ternaires.
+4. Les exemples couvrent la génération d'entropie, la division récursive de tâches et la vérification de primalité.
+5. Certains fichiers illustrent l'utilisation de `pthread` pour paralléliser la construction de buffers mémoire.
+6. La structure du dépôt facilite l'intégration future de code Triton via un chemin de build reproductible.
+7. Des fichiers README complémentaires expliquent comment compiler et tester chaque module.

--- a/Clisa/CLisa_Prime/AGENTS.md
+++ b/Clisa/CLisa_Prime/AGENTS.md
@@ -17,3 +17,13 @@ if __name__ == "__main__":
 7. AGENT inserted automatically
 
 La logique ricane, un brin mélancolique.
+
+---
+### Aperçu technique en 7 points
+1. `casino1031.cpp` génère un entier de 2084 bits et applique Miller‑Rabin pour tester sa primalité.
+2. Les fichiers `hexentropy_*` produisent des séquences hexadécimales en répartissant le travail via `pthread`.
+3. `brochetcore.c` montre une division récursive de buffer en fixant l’affinité CPU des threads.
+4. `__desfoisque.c` illustre une bifurcation de tâches où un entier est divisé par deux jusqu’à la base.
+5. `iqq.cpp` offre une routine vectorisée pour quantifier des valeurs float 128 en octets.
+6. `gui/` contient une interface Qt minimaliste et la fonction `generateRandom2084Bit` partagée via un header.
+7. Les outils annexes (`pilouface_rapide.c`, `random_hex_string.c`, etc.) servent de démonstrations rapides d’accès à l’entropie système.

--- a/Clisa/CLisa_Prime/gui/AGENTS.md
+++ b/Clisa/CLisa_Prime/gui/AGENTS.md
@@ -17,3 +17,13 @@ if __name__ == "__main__":
 7. AGENT inserted automatically
 
 Les fichiers dansent sous un halo fantastique.
+
+---
+### Aperçu technique en 7 points
+1. `big_random.hpp` expose `generateRandom2084Bit`, un utilitaire pour fabriquer un entier de 2084 bits.
+2. `main_gui.cpp` lance une petite application Qt affichant et copiant ce nombre via deux boutons.
+3. L’interface stocke l’historique des 27 derniers nombres dans un tableau 3×3×3.
+4. Le code utilise `QApplication`, `QTextEdit`, `QPushButton` et `QClipboard` des Qt Widgets.
+5. Le README fournit les commandes `g++` nécessaires à la compilation avec `pkg-config`.
+6. Les fichiers démontrent le passage d’un pointeur sur tableau pour manipuler l’historique.
+7. L’ensemble sert de prototype graphique minimal pour tester la génération d’entiers massifs.

--- a/Clisa/CLisa_Prime/hexentropy/AGENTS.md
+++ b/Clisa/CLisa_Prime/hexentropy/AGENTS.md
@@ -17,3 +17,13 @@ if __name__ == "__main__":
 7. AGENT inserted automatically
 
 Les modules complotent, rires électroniques.
+
+---
+### Aperçu technique en 7 points
+1. `hexentropy_tree.c` génère récursivement un motif hexadécimal en branchant deux threads par niveau.
+2. `hexentropy_v0.c` explore une version plus simple avec profondeur et taille limitées.
+3. `hexentropy_v1.c` affine la stratégie en fonction de la parité du segment traité.
+4. `hexentropy_tree_try.c` fournit un squelette d’examen pour compléter l’implémentation.
+5. Les fichiers README détaillent les choix algorithmiques et les options de compilation.
+6. Les programmes s’appuient sur `getrandom` pour collecter de l’entropie depuis le noyau.
+7. Chaque variante affiche le buffer final en hexadécimal afin de vérifier visuellement la distribution.


### PR DESCRIPTION
## Summary
- document Clisa folder with technical bullet points
- summarise prototypes in CLisa_Prime
- note key features of the hexentropy and gui modules

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687582866a088329b5b43f72025fe33c