### PR TITLE
Add technical overview of Lisa internal

### DIFF
--- a/Lisa/Lisa/Lisa_internal/AGENTS.md
+++ b/Lisa/Lisa/Lisa_internal/AGENTS.md
@@ -17,3 +17,12 @@ if __name__ == "__main__":
 7. AGENT inserted automatically
 
 Les fichiers dansent sous un halo fantastique.
+
+### Résumé technique
+- `Context.py` gère un contexte global logarithmique et fournit des fonctions de nettoyage, de résumé et de mesure basée sur un nombre premier.
+- `EventHandler.py` regroupe des callbacks symbolisés par des emojis pour signaler les états internes de Lisa.
+- `LisaEventEngine.py` définit une file prioritaire d'événements, des triggers conditionnels et un stockage de faits persistants.
+- `LisaEventHandler.py` liste des événements hiérarchisés (sensoriel, primaire, contextuel...) avec diverses fonctions d'activation.
+- `Lisa_Tokenizer.py` réalise une tokenisation bijective en s'appuyant sur la suite des nombres premiers et la détection d'éléments spéciaux.
+- `LisaPipelineV2.py`, `FeedGenerator.py` et `LisaTurnManager.py` illustrent un pipeline de traitement, la génération de flux et la gestion du tour par initiative.
+- `LisaADNxQ.py` et `LisaContextProcessorV2.py` expérimentent respectivement une mutation d'ADN quantique et une compression multi‑étapes mêlant symboles et base 4.


### PR DESCRIPTION
## Summary
- fill AGENTS in `Lisa/Lisa/Lisa_internal`
- add 7‑point overview of the modules

## Testing
- `python -m py_compile Lisa/Lisa/Lisa_internal/*.py`

------
https://chatgpt.com/codex/tasks/task_e_687583a0037883299f5924beb6b4ce66