### PR TITLE
Insert blank lines in AGENTS.md files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,8 @@ if __name__ == "__main__":
 7. AGENT inserted automatically
 
 Ce dossier chante, rieur, ses octets en cadence.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Clisa/AGENTS.md
+++ b/Clisa/AGENTS.md
@@ -29,6 +29,8 @@ La logique ricane, un brin mélancolique.
 5. Certains fichiers illustrent l'utilisation de `pthread` pour paralléliser la construction de buffers mémoire.
 6. La structure du dépôt facilite l'intégration future de code Triton via un chemin de build reproductible.
 7. Des fichiers README complémentaires expliquent comment compiler et tester chaque module.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Clisa/CLisa_Prime/AGENTS.md
+++ b/Clisa/CLisa_Prime/AGENTS.md
@@ -29,6 +29,8 @@ La logique ricane, un brin mélancolique.
 5. `iqq.cpp` offre une routine vectorisée pour quantifier des valeurs float 128 en octets.
 6. `gui/` contient une interface Qt minimaliste et la fonction `generateRandom2084Bit` partagée via un header.
 7. Les outils annexes (`pilouface_rapide.c`, `random_hex_string.c`, etc.) servent de démonstrations rapides d’accès à l’entropie système.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Clisa/CLisa_Prime/gui/AGENTS.md
+++ b/Clisa/CLisa_Prime/gui/AGENTS.md
@@ -29,6 +29,8 @@ Les fichiers dansent sous un halo fantastique.
 5. Le README fournit les commandes `g++` nécessaires à la compilation avec `pkg-config`.
 6. Les fichiers démontrent le passage d’un pointeur sur tableau pour manipuler l’historique.
 7. L’ensemble sert de prototype graphique minimal pour tester la génération d’entiers massifs.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Clisa/CLisa_Prime/hexentropy/AGENTS.md
+++ b/Clisa/CLisa_Prime/hexentropy/AGENTS.md
@@ -29,6 +29,8 @@ Les modules complotent, rires électroniques.
 5. Les fichiers README détaillent les choix algorithmiques et les options de compilation.
 6. Les programmes s’appuient sur `getrandom` pour collecter de l’entropie depuis le noyau.
 7. Chaque variante affiche le buffer final en hexadécimal afin de vérifier visuellement la distribution.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Ctest_env/AGENTS.md
+++ b/Ctest_env/AGENTS.md
@@ -19,6 +19,8 @@ if __name__ == "__main__":
 7. AGENT inserted automatically
 
 Les scripts se chamaillent, farceurs d'informatique.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Lisa/AGENTS.md
+++ b/Lisa/AGENTS.md
@@ -28,6 +28,8 @@ Ici les bits s'agitent, clowns d'un jour agités.
 - **Structure du dépôt** : la sous-arborescence `Lisa/` abrite l'implémentation principale et ses modules internes.
 - **Construction d'outils** : divers scripts shell et Python servent à préparer l'environnement et expérimenter des idées.
 - **Orientation R&D** : la plupart des fichiers sont des prototypes servant de base à des développements plus poussés.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Lisa/Lisa/AGENTS.md
+++ b/Lisa/Lisa/AGENTS.md
@@ -28,6 +28,8 @@ La logique ricane, un brin mélancolique.
 - **Lisa_internal/** : anciens prototypes autour de l'AGI et de la tokenisation.
 - **Lisa_Fractal/** et **Stochastiques/** : espaces expérimentaux aux contenus variés.
 - **Organisation modulaire** : chaque sous-dossier explore une approche différente de la cognition artificielle.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Lisa/Lisa/Lisa_AntModule/AGENTS.md
+++ b/Lisa/Lisa/Lisa_AntModule/AGENTS.md
@@ -28,6 +28,8 @@ Les scripts se chamaillent, farceurs d'informatique.
 5. **Résonance et propagation** : `PheromoneResonanceSimulator.py` illustre la diffusion d'un champ de phéromones en trois dimensions au cours du temps.
 6. **Parsing d'équations** : `PheromonEquationParser.py` convertit les équations différentielles en versions ornées d'émojis pour une lecture ludique.
 7. **Scripts utilitaires** : divers fichiers gèrent l'extraction de conversations JSON, la condensation de texte ou l'obtention d'informations chimiques depuis PubChem.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Lisa/Lisa/Lisa_AntModule/Plots/AGENTS.md
+++ b/Lisa/Lisa/Lisa_AntModule/Plots/AGENTS.md
@@ -19,6 +19,8 @@ if __name__ == "__main__":
 7. AGENT inserted automatically
 
 Ce dossier chante, rieur, ses octets en cadence.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Lisa/Lisa/Lisa_AntModule/Plots/Molecules/3520251138_Ant/AGENTS.md
+++ b/Lisa/Lisa/Lisa_AntModule/Plots/Molecules/3520251138_Ant/AGENTS.md
@@ -19,6 +19,8 @@ if __name__ == "__main__":
 7. AGENT inserted automatically
 
 La logique ricane, un brin mélancolique.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Lisa/Lisa/Lisa_AntModule/Plots/Molecules/3620251258_Ant/AGENTS.md
+++ b/Lisa/Lisa/Lisa_AntModule/Plots/Molecules/3620251258_Ant/AGENTS.md
@@ -19,6 +19,8 @@ if __name__ == "__main__":
 7. AGENT inserted automatically
 
 La logique ricane, un brin mélancolique.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Lisa/Lisa/Lisa_AntModule/Plots/Molecules/362025153_Ant/AGENTS.md
+++ b/Lisa/Lisa/Lisa_AntModule/Plots/Molecules/362025153_Ant/AGENTS.md
@@ -19,6 +19,8 @@ if __name__ == "__main__":
 7. AGENT inserted automatically
 
 Dans cette antre codée, l'humour pointe son nez.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Lisa/Lisa/Lisa_AntModule/Plots/Molecules/362025221_Ant/AGENTS.md
+++ b/Lisa/Lisa/Lisa_AntModule/Plots/Molecules/362025221_Ant/AGENTS.md
@@ -19,6 +19,8 @@ if __name__ == "__main__":
 7. AGENT inserted automatically
 
 Ici les bits s'agitent, clowns d'un jour agités.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Lisa/Lisa/Lisa_AntModule/Plots/Molecules/362025343_Ant/AGENTS.md
+++ b/Lisa/Lisa/Lisa_AntModule/Plots/Molecules/362025343_Ant/AGENTS.md
@@ -19,6 +19,8 @@ if __name__ == "__main__":
 7. AGENT inserted automatically
 
 Les fichiers dansent sous un halo fantastique.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Lisa/Lisa/Lisa_AntModule/Plots/Molecules/AGENTS.md
+++ b/Lisa/Lisa/Lisa_AntModule/Plots/Molecules/AGENTS.md
@@ -19,6 +19,8 @@ if __name__ == "__main__":
 7. AGENT inserted automatically
 
 Ici les bits s'agitent, clowns d'un jour agités.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Lisa/Lisa/Lisa_Fractal/AGENTS.md
+++ b/Lisa/Lisa/Lisa_Fractal/AGENTS.md
@@ -19,6 +19,8 @@ if __name__ == "__main__":
 7. AGENT inserted automatically
 
 Ici les bits s'agitent, clowns d'un jour agités.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Lisa/Lisa/Lisa_Genie/AGENTS.md
+++ b/Lisa/Lisa/Lisa_Genie/AGENTS.md
@@ -26,6 +26,8 @@ Ici les bits s'agitent, clowns d'un jour agités.
 - BirdFeedbackAPI.py expose une API Flask et BirdFeedbackDisplay.html sert l'interface web.
 - Divers scripts comme LeScript17_QuiFaitFlip.py transforment des chaines ASCII ou experimentent avec regex.
 - Dockerfile et QuantumEmojiImpl.java montrent des configurations et une version Java de l'interface.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Lisa/Lisa/Lisa_Genie/Act1_ChatToAPI/AGENTS.md
+++ b/Lisa/Lisa/Lisa_Genie/Act1_ChatToAPI/AGENTS.md
@@ -26,6 +26,8 @@ Ici les bits s'agitent, clowns d'un jour agités.
 - La structure de dossier reste identique entre Part1, Part2 et Part3.
 - Ces fragments illustrent des manipulations de fichiers simples.
 - Peu ou pas de dependances externes sont necessaires.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Lisa/Lisa/Lisa_Genie/Act1_ChatToAPI/Act1_ChatToAPI_Part1/AGENTS.md
+++ b/Lisa/Lisa/Lisa_Genie/Act1_ChatToAPI/Act1_ChatToAPI_Part1/AGENTS.md
@@ -26,6 +26,8 @@ Les modules complotent, rires électroniques.
 - Fait partie de la sequence Act1 montrant un flux basique.
 - Peut etre adapte pour tester l'envoi de donnees a une API ulterieure.
 - Reste un code tres court, uniquement a des fins de demonstration.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Lisa/Lisa/Lisa_Genie/Act1_ChatToAPI/Act1_ChatToAPI_Part2/AGENTS.md
+++ b/Lisa/Lisa/Lisa_Genie/Act1_ChatToAPI/Act1_ChatToAPI_Part2/AGENTS.md
@@ -26,6 +26,8 @@ Les modules complotent, rires électroniques.
 - Les fichiers d'entree sont courts et purement demonstratifs.
 - Peut servir d'exercice pour manipuler fichiers et chemins.
 - L'ensemble reste tres compact et pedagogique.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Lisa/Lisa/Lisa_Genie/Act1_ChatToAPI/Act1_ChatToAPI_Part3/AGENTS.md
+++ b/Lisa/Lisa/Lisa_Genie/Act1_ChatToAPI/Act1_ChatToAPI_Part3/AGENTS.md
@@ -26,6 +26,8 @@ La logique ricane, un brin mélancolique.
 - Utile pour valider les chemins relatifs avant de complexifier.
 - Peut etre modifie pour accueillir des arguments de ligne de commande.
 - Reste surtout un exemple didactique tres simple.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Lisa/Lisa/Lisa_Genie/Act2_ChatToAPI/AGENTS.md
+++ b/Lisa/Lisa/Lisa_Genie/Act2_ChatToAPI/AGENTS.md
@@ -26,6 +26,8 @@ Les scripts se chamaillent, farceurs d'informatique.
 - Sert principalement de squelette pour des experiments plus avances.
 - Organisation identique a l'acte 1 pour faciliter la progression.
 - Conserve une dependance tres reduite a la bibliotheque standard.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Lisa/Lisa/Lisa_Genie/Act2_ChatToAPI/Act2_ChatToAPI_Part1/AGENTS.md
+++ b/Lisa/Lisa/Lisa_Genie/Act2_ChatToAPI/Act2_ChatToAPI_Part1/AGENTS.md
@@ -26,6 +26,8 @@ Ici les bits s'agitent, clowns d'un jour agités.
 - Aucun traitement supplementaire n'est ajoute.
 - Sert de base a d'eventuelles evolutions connectees a des APIs.
 - Reste un exemple epure limite aux entrees/sorties basiques.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Lisa/Lisa/Lisa_Genie/Act2_ChatToAPI/Act2_ChatToAPI_Part2/AGENTS.md
+++ b/Lisa/Lisa/Lisa_Genie/Act2_ChatToAPI/Act2_ChatToAPI_Part2/AGENTS.md
@@ -26,6 +26,8 @@ Les scripts se chamaillent, farceurs d'informatique.
 - Prevu pour evoluer vers un traitement plus riche a l'etape suivante.
 - Utile pour tester la repetition des flux de donnees simples.
 - Minimaliste et rapide a executer dans n'importe quel environnement.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Lisa/Lisa/Lisa_Genie/Act2_ChatToAPI/Act2_ChatToAPI_Part3/AGENTS.md
+++ b/Lisa/Lisa/Lisa_Genie/Act2_ChatToAPI/Act2_ChatToAPI_Part3/AGENTS.md
@@ -26,6 +26,8 @@ Dans cette antre codée, l'humour pointe son nez.
 - Destine a etre enrichi une fois la phase de prototypage terminee.
 - Montre comment separer les essais dans plusieurs sous-dossiers.
 - Propose un exemple simple et replicable pour plus tard.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Lisa/Lisa/Lisa_Genie/Act3_ChatToAPI/AGENTS.md
+++ b/Lisa/Lisa/Lisa_Genie/Act3_ChatToAPI/AGENTS.md
@@ -26,6 +26,8 @@ Les modules complotent, rires électroniques.
 - Cet acte finalise la mise en place de la structure d'exemples.
 - Prepare la transition vers des modules plus complexes par la suite.
 - Reste minimaliste pour faciliter l'execution rapide.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Lisa/Lisa/Lisa_Genie/Act3_ChatToAPI/Act3_ChatToAPI_Part1/AGENTS.md
+++ b/Lisa/Lisa/Lisa_Genie/Act3_ChatToAPI/Act3_ChatToAPI_Part1/AGENTS.md
@@ -26,6 +26,8 @@ Ici les bits s'agitent, clowns d'un jour agités.
 - L'objectif est de tester la structure multi-parties.
 - Peut etre revisite pour accueillir de nouvelles fonctions plus tard.
 - Sert actuellement de simple exemple pedagogique.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Lisa/Lisa/Lisa_Genie/Act3_ChatToAPI/Act3_ChatToAPI_Part2/AGENTS.md
+++ b/Lisa/Lisa/Lisa_Genie/Act3_ChatToAPI/Act3_ChatToAPI_Part2/AGENTS.md
@@ -26,6 +26,8 @@ Dans cette antre codée, l'humour pointe son nez.
 - Conserve le code tres court pour mise en place rapide.
 - Sert de base avant l'integration de fonctions plus complexes.
 - Simple demonstration de structure en dossiers separes.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Lisa/Lisa/Lisa_Genie/Act3_ChatToAPI/Act3_ChatToAPI_Part3/AGENTS.md
+++ b/Lisa/Lisa/Lisa_Genie/Act3_ChatToAPI/Act3_ChatToAPI_Part3/AGENTS.md
@@ -26,6 +26,8 @@ Ici les bits s'agitent, clowns d'un jour agités.
 - Utile pour repartir d'une base saine avant d'ajouter l'API.
 - Simplicite volontaire pour garder un schema clair.
 - Prefigure la future extension vers des modules plus interessants.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Lisa/Lisa/Lisa_Genie/LeGenieCode/AGENTS.md
+++ b/Lisa/Lisa/Lisa_Genie/LeGenieCode/AGENTS.md
@@ -26,6 +26,8 @@ Les scripts se chamaillent, farceurs d'informatique.
 - Aucun programme complexe n'est lance directement depuis ici.
 - Sert de laboratoire pour ecrire ou tester des fragments experimentaux.
 - Fait office d'annexe pour les curieux du codage creatif.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Lisa/Lisa/Lisa_internal/AGENTS.md
+++ b/Lisa/Lisa/Lisa_internal/AGENTS.md
@@ -28,6 +28,8 @@ Les fichiers dansent sous un halo fantastique.
 - `Lisa_Tokenizer.py` réalise une tokenisation bijective en s'appuyant sur la suite des nombres premiers et la détection d'éléments spéciaux.
 - `LisaPipelineV2.py`, `FeedGenerator.py` et `LisaTurnManager.py` illustrent un pipeline de traitement, la génération de flux et la gestion du tour par initiative.
 - `LisaADNxQ.py` et `LisaContextProcessorV2.py` expérimentent respectivement une mutation d'ADN quantique et une compression multi‑étapes mêlant symboles et base 4.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Lisa/Lisa/Lisa_internal/Lisa_old/AGENTS.md
+++ b/Lisa/Lisa/Lisa_internal/Lisa_old/AGENTS.md
@@ -19,6 +19,8 @@ if __name__ == "__main__":
 7. AGENT inserted automatically
 
 La logique ricane, un brin mélancolique.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Lisa/Lisa/Lisa_internal/Neural_old/AGENTS.md
+++ b/Lisa/Lisa/Lisa_internal/Neural_old/AGENTS.md
@@ -19,6 +19,8 @@ if __name__ == "__main__":
 7. AGENT inserted automatically
 
 Dans cette antre codée, l'humour pointe son nez.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Lisa/Lisa/Prime/AGENTS.md
+++ b/Lisa/Lisa/Prime/AGENTS.md
@@ -28,6 +28,8 @@ Dans cette antre codée, l'humour pointe son nez.
 - **Modules auxiliaires** : scripts de mutation, générateurs de nombres hybrides et outils d'analyse spectrale.
 - **Explorations archivées** : répertoires `Prime_old` et `Spectral_old` conservent d'anciens tests pour référence.
 - **Orienté recherche cryptographique** : l'ensemble sert à étudier les propriétés rares des grands nombres premiers.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Lisa/Lisa/Prime/Casino_old/AGENTS.md
+++ b/Lisa/Lisa/Prime/Casino_old/AGENTS.md
@@ -19,6 +19,8 @@ if __name__ == "__main__":
 7. AGENT inserted automatically
 
 Dans cette antre codée, l'humour pointe son nez.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Lisa/Lisa/Prime/Prime_old/AGENTS.md
+++ b/Lisa/Lisa/Prime/Prime_old/AGENTS.md
@@ -19,6 +19,8 @@ if __name__ == "__main__":
 7. AGENT inserted automatically
 
 Dans cette antre codée, l'humour pointe son nez.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Lisa/Lisa/Prime/Spectral_old/AGENTS.md
+++ b/Lisa/Lisa/Prime/Spectral_old/AGENTS.md
@@ -19,6 +19,8 @@ if __name__ == "__main__":
 7. AGENT inserted automatically
 
 Les scripts se chamaillent, farceurs d'informatique.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Lisa/Lisa/Stochastiques/AGENTS.md
+++ b/Lisa/Lisa/Stochastiques/AGENTS.md
@@ -19,6 +19,8 @@ if __name__ == "__main__":
 7. AGENT inserted automatically
 
 Les fichiers dansent sous un halo fantastique.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Lisa/Lisa/Stochastiques/genie/AGENTS.md
+++ b/Lisa/Lisa/Stochastiques/genie/AGENTS.md
@@ -19,6 +19,8 @@ if __name__ == "__main__":
 7. AGENT inserted automatically
 
 Les modules complotent, rires électroniques.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Lisa/Lisa/Stochastiques/genie/memoire_asst_0DTRD8wafVNuTefgYPEWzEtY/AGENTS.md
+++ b/Lisa/Lisa/Stochastiques/genie/memoire_asst_0DTRD8wafVNuTefgYPEWzEtY/AGENTS.md
@@ -19,6 +19,8 @@ if __name__ == "__main__":
 7. AGENT inserted automatically
 
 Ici les bits s'agitent, clowns d'un jour agités.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Lisa/Lisa/Stochastiques/genie/memoire_asst_9QjYIdND8iYSsBN6D25udXrl/AGENTS.md
+++ b/Lisa/Lisa/Stochastiques/genie/memoire_asst_9QjYIdND8iYSsBN6D25udXrl/AGENTS.md
@@ -19,6 +19,8 @@ if __name__ == "__main__":
 7. AGENT inserted automatically
 
 Les fichiers dansent sous un halo fantastique.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Lisa/Lisa/Stochastiques/genie/memoire_asst_R11hPhCEZO3pK2vqTC0V4rby/AGENTS.md
+++ b/Lisa/Lisa/Stochastiques/genie/memoire_asst_R11hPhCEZO3pK2vqTC0V4rby/AGENTS.md
@@ -19,6 +19,8 @@ if __name__ == "__main__":
 7. AGENT inserted automatically
 
 Dans cette antre codée, l'humour pointe son nez.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Lisa/Lisa/Stochastiques/genie/memoire_asst_XkLwGNuFzUHq9ugfk8XyHMkI/AGENTS.md
+++ b/Lisa/Lisa/Stochastiques/genie/memoire_asst_XkLwGNuFzUHq9ugfk8XyHMkI/AGENTS.md
@@ -19,6 +19,8 @@ if __name__ == "__main__":
 7. AGENT inserted automatically
 
 Ici les bits s'agitent, clowns d'un jour agités.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Lisa/Lisa/Stochastiques/genie/memoire_asst_YxE2Vivhy9lJwPpIXY7BtOZn/AGENTS.md
+++ b/Lisa/Lisa/Stochastiques/genie/memoire_asst_YxE2Vivhy9lJwPpIXY7BtOZn/AGENTS.md
@@ -19,6 +19,8 @@ if __name__ == "__main__":
 7. AGENT inserted automatically
 
 Les scripts se chamaillent, farceurs d'informatique.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Lisa/Lisa/Stochastiques/genie/memoire_asst_xfS0mC4cG8pkZ57DTzJ6pKZO/AGENTS.md
+++ b/Lisa/Lisa/Stochastiques/genie/memoire_asst_xfS0mC4cG8pkZ57DTzJ6pKZO/AGENTS.md
@@ -19,6 +19,8 @@ if __name__ == "__main__":
 7. AGENT inserted automatically
 
 Les fichiers dansent sous un halo fantastique.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Lisa/Lisa/Stochastiques/outputs/AGENTS.md
+++ b/Lisa/Lisa/Stochastiques/outputs/AGENTS.md
@@ -19,6 +19,8 @@ if __name__ == "__main__":
 7. AGENT inserted automatically
 
 Ce dossier chante, rieur, ses octets en cadence.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Lisa/share/AGENTS.md
+++ b/Lisa/share/AGENTS.md
@@ -19,6 +19,8 @@ if __name__ == "__main__":
 7. AGENT inserted automatically
 
 La logique ricane, un brin mélancolique.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Lisa/share/man/AGENTS.md
+++ b/Lisa/share/man/AGENTS.md
@@ -19,6 +19,8 @@ if __name__ == "__main__":
 7. AGENT inserted automatically
 
 Ici les bits s'agitent, clowns d'un jour agités.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/Lisa/share/man/man1/AGENTS.md
+++ b/Lisa/share/man/man1/AGENTS.md
@@ -19,6 +19,8 @@ if __name__ == "__main__":
 7. AGENT inserted automatically
 
 Les modules complotent, rires électroniques.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/codex_summaries/AGENTS.md
+++ b/codex_summaries/AGENTS.md
@@ -19,6 +19,8 @@ if __name__ == "__main__":
 7. AGENT inserted automatically
 
 Dans cette antre codée, l'humour pointe son nez.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/hackathon_guides/0_dev_cloud_manual/AGENTS.md
+++ b/hackathon_guides/0_dev_cloud_manual/AGENTS.md
@@ -19,6 +19,8 @@ if __name__ == "__main__":
 7. AGENT inserted automatically
 
 Ici les bits s'agitent, clowns d'un jour agités.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/hackathon_guides/0_dev_cloud_manual/assets/AGENTS.md
+++ b/hackathon_guides/0_dev_cloud_manual/assets/AGENTS.md
@@ -19,6 +19,8 @@ if __name__ == "__main__":
 7. AGENT inserted automatically
 
 Dans cette antre codée, l'humour pointe son nez.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/hackathon_guides/1_developing_vllm/AGENTS.md
+++ b/hackathon_guides/1_developing_vllm/AGENTS.md
@@ -19,6 +19,8 @@ if __name__ == "__main__":
 7. AGENT inserted automatically
 
 Les fichiers dansent sous un halo fantastique.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/hackathon_guides/2_perf_accuracy_profile_vllm/AGENTS.md
+++ b/hackathon_guides/2_perf_accuracy_profile_vllm/AGENTS.md
@@ -19,6 +19,8 @@ if __name__ == "__main__":
 7. AGENT inserted automatically
 
 Les modules complotent, rires électroniques.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/hackathon_guides/2_perf_accuracy_profile_vllm/assets/AGENTS.md
+++ b/hackathon_guides/2_perf_accuracy_profile_vllm/assets/AGENTS.md
@@ -19,6 +19,8 @@ if __name__ == "__main__":
 7. AGENT inserted automatically
 
 Les scripts se chamaillent, farceurs d'informatique.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/hackathon_guides/3_optimization_pointers/AGENTS.md
+++ b/hackathon_guides/3_optimization_pointers/AGENTS.md
@@ -19,6 +19,8 @@ if __name__ == "__main__":
 7. AGENT inserted automatically
 
 La logique ricane, un brin mélancolique.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/hackathon_guides/AGENTS.md
+++ b/hackathon_guides/AGENTS.md
@@ -19,6 +19,8 @@ if __name__ == "__main__":
 7. AGENT inserted automatically
 
 Ce dossier chante, rieur, ses octets en cadence.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -28,6 +28,8 @@ Ici les bits s'agitent, clowns d'un jour agités.
 5. Profile mode collects traces for deeper analysis into `results_with_profile`.
 6. The `profile_without_hipgraph` folder holds an example JSON trace for offline viewing.
 7. A large `vllm/` directory resides here but is excluded from this summary.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/scripts/profile_without_hipgraph/AGENTS.md
+++ b/scripts/profile_without_hipgraph/AGENTS.md
@@ -19,6 +19,8 @@ if __name__ == "__main__":
 7. AGENT inserted automatically
 
 Ici les bits s'agitent, clowns d'un jour agités.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/workshop/0_ai_agent/AGENTS.md
+++ b/workshop/0_ai_agent/AGENTS.md
@@ -19,6 +19,8 @@ if __name__ == "__main__":
 7. AGENT inserted automatically
 
 Ici les bits s'agitent, clowns d'un jour agités.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/workshop/1_optimized_vllm/AGENTS.md
+++ b/workshop/1_optimized_vllm/AGENTS.md
@@ -19,6 +19,8 @@ if __name__ == "__main__":
 7. AGENT inserted automatically
 
 Ce dossier chante, rieur, ses octets en cadence.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/workshop/1_optimized_vllm/assets/AGENTS.md
+++ b/workshop/1_optimized_vllm/assets/AGENTS.md
@@ -19,6 +19,8 @@ if __name__ == "__main__":
 7. AGENT inserted automatically
 
 Les scripts se chamaillent, farceurs d'informatique.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/workshop/2_optimized_kernels/AGENTS.md
+++ b/workshop/2_optimized_kernels/AGENTS.md
@@ -19,6 +19,8 @@ if __name__ == "__main__":
 7. AGENT inserted automatically
 
 Ici les bits s'agitent, clowns d'un jour agités.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »

--- a/workshop/AGENTS.md
+++ b/workshop/AGENTS.md
@@ -19,6 +19,8 @@ if __name__ == "__main__":
 7. AGENT inserted automatically
 
 Les fichiers dansent sous un halo fantastique.
+
+
 Le Livre d'Or : « - Lundi 7h du matin, Lundie oui disons, pose son 1er commit... un lundi 14 juillet. Vive la République kek.
 - <you agent message> 
 »


### PR DESCRIPTION
## Summary
- insert two blank lines before the phrase "Le Livre d'Or" in all AGENTS.md files
- exclude `scripts/vllm` from modification

## Testing
- `pytest -q --ignore=scripts/vllm`

------
https://chatgpt.com/codex/tasks/task_e_687594aa83548329882d097e8be33d29