### PR TITLE
Fix hexentropy recursion

### DIFF
--- a/Clisa/CLisa_Prime/hexentropy_v1.c
+++ b/Clisa/CLisa_Prime/hexentropy_v1.c
@@ -24,19 +24,22 @@ static int random_bit() {
     return b & 1;
 }
 
+// Return a random nibble (0-15)
+static unsigned char rand_hexbit() {
+    unsigned char b;
+    if (getrandom(&b, 1, 0) != 1) {
+        perror("getrandom");
+        exit(EXIT_FAILURE);
+    }
+    return b & 0x0F;
+}
+
 // Fill buffer with random bytes
 static void fill_random(unsigned char *buf, size_t len) {
     if (getrandom(buf, len, 0) != (ssize_t)len) {
         perror("getrandom");
         exit(EXIT_FAILURE);
     }
-}
-
-// Wrapper to use fill_random as a thread routine
-static void *fill_random_thread(void *arg) {
-    WorkerCtx ctx = *(WorkerCtx *)arg;
-    fill_random(ctx.buffer, ctx.length);
-    return NULL;
 }
 
 // Recursive worker implementing the described strategy
@@ -53,30 +56,25 @@ static void *hexentropy_worker(void *arg) {
     }
 
     pthread_t t1, t2;
-    size_t left_len, right_len, mid;
+    size_t half;
 
     if (ctx.length % 2 == 0) {
-        // Even length: coin toss first, then recurse on both halves
-        left_len = (ctx.length - 1) / 2;
-        right_len = ctx.length - left_len - 1;
-        mid = left_len;
-        ctx.buffer[mid] = random_bit() ? 0x07 : 0x00;
+        // Even length: split evenly and recurse on both halves
+        half = ctx.length / 2;
 
-        WorkerCtx left = { ctx.buffer, left_len, ctx.depth + 1 };
-        WorkerCtx right = { ctx.buffer + mid + 1, right_len, ctx.depth + 1 };
+        WorkerCtx left = { ctx.buffer, half, ctx.depth + 1 };
+        WorkerCtx right = { ctx.buffer + half, half, ctx.depth + 1 };
         pthread_create(&t1, NULL, hexentropy_worker, &left);
         pthread_create(&t2, NULL, hexentropy_worker, &right);
     } else {
-        // Odd length: coin toss and fill both halves without recursion
-        left_len = ctx.length / 2;
-        right_len = ctx.length - left_len - 1;
-        mid = left_len;
-        ctx.buffer[mid] = random_bit() ? 0x07 : 0x00;
+        // Odd length: insert one random nibble then recurse on each half
+        half = (ctx.length - 1) / 2;
+        ctx.buffer[half] = rand_hexbit();
 
-        WorkerCtx left = { ctx.buffer, left_len, ctx.depth + 1 };
-        WorkerCtx right = { ctx.buffer + mid + 1, right_len, ctx.depth + 1 };
-        pthread_create(&t1, NULL, fill_random_thread, &left);
-        pthread_create(&t2, NULL, fill_random_thread, &right);
+        WorkerCtx left = { ctx.buffer, half, ctx.depth + 1 };
+        WorkerCtx right = { ctx.buffer + half + 1, half, ctx.depth + 1 };
+        pthread_create(&t1, NULL, hexentropy_worker, &left);
+        pthread_create(&t2, NULL, hexentropy_worker, &right);
     }
 
     pthread_join(t1, NULL);

--- a/Clisa/CLisa_Prime/hexentropy_v1_README.md
+++ b/Clisa/CLisa_Prime/hexentropy_v1_README.md
@@ -3,11 +3,11 @@
 Cette version expérimente une stratégie légèrement différente pour générer une chaîne hexadécimale en remplissant un buffer partagé via plusieurs threads.
 
 ## 7 points de réflexion (et tâches associées)
-1. **Recursion contrôlée** – Seuls les cas pairs repartent récursivement sur `(n-1)/2`.
+1. **Division équilibrée** – Les longueurs paires sont coupées en deux segments identiques récursifs.
    *Tâche : mesurer la profondeur optimale en fonction du nombre de cœurs.*
-2. **Cas impair simplifié** – On se contente de deux threads de remplissage plus le tirage central.
+2. **Cas impair** – On place un nibble aléatoire au centre puis on lance la récursion sur les deux moitiés.
    *Tâche : vérifier si ce choix réduit réellement la contention.*
-3. **Gestion du milieu** – Le byte central est tiré avec `random_bit` (`0x00` ou `0x07`).
+3. **Gestion du milieu** – Le byte central provient de `rand_hexbit` (valeur 0‑15).
    *Tâche : observer la distribution obtenue sur de grands volumes.*
 4. **Limites de tailles** – `SMALL_CHUNK` impose un seuil sous lequel on évite les threads.
    *Tâche : ajuster ce seuil pour ne pas gaspiller de ressources.*
@@ -21,8 +21,8 @@ Cette version expérimente une stratégie légèrement différente pour génére
 ## Rôle global des fonctions
 - `random_bit` : renvoie un bit aléatoire.
 - `fill_random` : lecture séquentielle de `len` octets aléatoires.
-- `fill_random_thread` : simple enveloppe pour lancer `fill_random` dans un thread.
-- `hexentropy_worker` : coeur récursif qui applique la stratégie pair/impair.
+- `rand_hexbit` : génère une valeur aléatoire sur 4 bits.
+- `hexentropy_worker` : coeur récursif qui applique la stratégie pair/impair uniquement via la récursion.
 - `main` : prépare le buffer, lance la première tâche et affiche le résultat.
 
 ## Explications par blocs de code
@@ -30,8 +30,8 @@ Cette version expérimente une stratégie légèrement différente pour génére
 2. **Constantes** – `MAX_DEPTH` et `SMALL_CHUNK` bornent respectivement la profondeur et la granularité minimum.
 3. **random_bit** – lit un octet via `getrandom` et renvoie son bit de poids faible.
 4. **fill_random** – remplissage linéaire utilisé dans les cas de base.
-5. **fill_random_thread** – petite fonction pour lancer `fill_random` en thread.
-6. **hexentropy_worker** – selon la parité, lance soit de nouveaux workers (pair), soit des threads simples (impair) après avoir écrit le byte central.
+5. **rand_hexbit** – renvoie un demi‑octet aléatoire.
+6. **hexentropy_worker** – applique la division paire/impair entièrement via la récursion.
 7. **main** – parse l’argument `n`, alloue la mémoire et affiche la chaîne finale au format hexadécimal.
 
 ## Compilation


### PR DESCRIPTION
## Summary
- update `hexentropy_worker` logic
- add `rand_hexbit` helper
- revise documentation for new algorithm

## Testing
- `gcc -pthread Clisa/CLisa_Prime/hexentropy_v1.c -o /tmp/hexentropy_v1 && ls -l /tmp/hexentropy_v1`
- `/tmp/hexentropy_v1 20 | head`
- `/tmp/hexentropy_v1 16`

------
https://chatgpt.com/codex/tasks/task_e_6875a4acb9388329b73d0adfee253504